### PR TITLE
temp fix to full height issue

### DIFF
--- a/angular-powerbi-poc/src/app/dashboard/dashboard.component.html
+++ b/angular-powerbi-poc/src/app/dashboard/dashboard.component.html
@@ -3,7 +3,7 @@
 </div>
 
 
-<div class="report-div" style="height: 100%">
+<div class="report-div">
     <powerbi-report [embedConfig]="reportConfig" [cssClassName]="reportClass" [phasedEmbedding]="phasedEmbeddingFlag" [eventHandlers]="eventHandlersMap">
     </powerbi-report>
 </div>

--- a/angular-powerbi-poc/src/app/dashboard/dashboard.component.scss
+++ b/angular-powerbi-poc/src/app/dashboard/dashboard.component.scss
@@ -4,7 +4,7 @@ Licensed under the MIT License. */
 .header {
   background: #3476ae 0 0 no-repeat padding-box;
   border: 1px solid #707070;
-  height: 55px;
+  height: 7.3vh;
 }
 
 .title {
@@ -76,7 +76,7 @@ button:hover {
 .footer {
   background: #eef3f8 0 0 no-repeat padding-box;
   bottom: 0;
-  height: 39px;
+  height: 5vh;
   opacity: 1;
   position: absolute;
   width: 100%;
@@ -99,3 +99,15 @@ button:hover {
   letter-spacing: 0;
   text-decoration: underline;
 }
+
+// .report-container {
+//   height: 800px !important;
+// }
+
+// .report-div {
+//   height: 800px !important;
+// }
+
+// iframe {
+//   height: 800px !important;
+// }

--- a/angular-powerbi-poc/src/app/dashboard/dashboard.component.ts
+++ b/angular-powerbi-poc/src/app/dashboard/dashboard.component.ts
@@ -26,7 +26,7 @@ export class DashboardComponent implements OnInit {
       navContentPaneEnabled: true,
       layoutType: models.LayoutType.Custom,
       customLayout: {
-        displayOption: models.DisplayOption.FitToWidth
+        displayOption: models.DisplayOption.FitToPage
       }
     }
   }

--- a/angular-powerbi-poc/src/styles.scss
+++ b/angular-powerbi-poc/src/styles.scss
@@ -1,1 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
+
+.report-container {
+  height: 81vh;
+  margin: 8px auto;
+  width: 100%;
+}


### PR DESCRIPTION
Finding a solution or a workaround to make the powerbi report occupy the full height of the display screen instead of a fixed height of ~150px

main changes in this fix to get a workaround are as follows:
- playing around with CSS overriding
- div and report div placements, and their relative positions in the DOM
- playing around with `reportConfig: IReportEmbedConfiguration` configurations